### PR TITLE
Enhance garden SPA with estimator and gallery

### DIFF
--- a/garden-spa/index.html
+++ b/garden-spa/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Garden Service Map</title>
+    <script type="module" src="/src/main.tsx"></script>
+  </head>
+  <body class="min-h-screen bg-green-50">
+    <div id="root"></div>
+  </body>
+</html>

--- a/garden-spa/package.json
+++ b/garden-spa/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "garden-spa",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.7.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/garden-spa/postcss.config.js
+++ b/garden-spa/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/garden-spa/src/App.tsx
+++ b/garden-spa/src/App.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { InfoPanel } from './components/InfoPanel';
+import { services } from './data';
+import { Hotspot } from './components/Hotspot';
+
+export default function App() {
+  const [active, setActive] = useState<string | null>(null);
+
+  return (
+    <div className="p-4 md:p-8 space-y-8">
+      <h1 className="text-2xl md:text-4xl font-bold text-center">
+        Discover your dream garden with transparent pricing!
+      </h1>
+
+      <div className="relative mx-auto max-w-xl h-96 rounded-lg shadow-inner bg-gradient-to-br from-green-100 via-green-200 to-green-300">
+        {services.map((service) => (
+          <Hotspot
+            key={service.id}
+            service={service}
+            onClick={() => setActive(service.id)}
+          />
+        ))}
+      </div>
+
+      <InfoPanel
+        service={services.find((s) => s.id === active)}
+        onClose={() => setActive(null)}
+      />
+
+      <section className="max-w-xl mx-auto space-y-2">
+        <h2 className="text-xl font-semibold">About Us</h2>
+        <p>
+          We are a professional landscaping company offering comprehensive services and premium materials.
+        </p>
+      </section>
+
+      <section className="max-w-xl mx-auto space-y-2">
+        <h2 className="text-xl font-semibold">Contact</h2>
+        <p>Phone: 123-456-789</p>
+        <p>Email: info@example.com</p>
+      </section>
+    </div>
+  );
+}

--- a/garden-spa/src/components/CostEstimator.tsx
+++ b/garden-spa/src/components/CostEstimator.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+interface Props {
+  price: number;
+}
+
+export const CostEstimator: React.FC<Props> = ({ price }) => {
+  const [area, setArea] = useState<number>(0);
+  const total = (area || 0) * price;
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm">Area (m²)</label>
+      <input
+        type="number"
+        value={area}
+        onChange={(e) => setArea(parseFloat(e.target.value))}
+        className="w-full border rounded p-2"
+        min="0"
+      />
+      <p className="text-sm">Estimated cost: <strong>{total.toFixed(2)} PLN</strong></p>
+    </div>
+  );
+};

--- a/garden-spa/src/components/Hotspot.tsx
+++ b/garden-spa/src/components/Hotspot.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type { Service } from '../data';
+import { positions } from '../positions';
+
+interface Props {
+  service: Service;
+  onClick: () => void;
+}
+
+export const Hotspot: React.FC<Props> = ({ service, onClick }) => (
+  <button
+    className="absolute flex items-center justify-center w-10 h-10 text-xl bg-white rounded-full shadow hover:bg-green-200 transition-colors"
+    style={positions[service.id]}
+    onClick={onClick}
+    aria-label={service.name}
+  >
+    {service.icon}
+  </button>
+);

--- a/garden-spa/src/components/InfoPanel.tsx
+++ b/garden-spa/src/components/InfoPanel.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { Service } from '../data';
+import { BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import { CostEstimator } from './CostEstimator';
+
+interface Props {
+  service: Service | undefined;
+  onClose: () => void;
+}
+
+export const InfoPanel: React.FC<Props> = ({ service, onClose }) => {
+  const [tab, setTab] = useState('offer');
+
+  if (!service) return null;
+
+  const comparison = [
+    { name: 'Us', price: service.price },
+    { name: 'Market', price: service.price * 1.2 },
+  ];
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex justify-center items-center p-4">
+      <div className="bg-white rounded-lg w-full max-w-md p-4 relative">
+        <button
+          className="absolute top-2 right-2 text-gray-500"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          ✕
+        </button>
+        <div className="mb-4 border-b flex space-x-4">
+          <button
+            className={`pb-2 ${tab === 'offer' ? 'border-b-2 border-green-500' : ''}`}
+            onClick={() => setTab('offer')}
+          >
+            Offer & Pricing
+          </button>
+          <button
+            className={`pb-2 ${tab === 'why' ? 'border-b-2 border-green-500' : ''}`}
+            onClick={() => setTab('why')}
+          >
+            Why Choose Us
+          </button>
+          <button
+            className={`pb-2 ${tab === 'gallery' ? 'border-b-2 border-green-500' : ''}`}
+            onClick={() => setTab('gallery')}
+          >
+            Gallery
+          </button>
+          <button
+            className={`pb-2 ${tab === 'estimate' ? 'border-b-2 border-green-500' : ''}`}
+            onClick={() => setTab('estimate')}
+          >
+            Estimate Cost
+          </button>
+          <button
+            className={`pb-2 ${tab === 'quote' ? 'border-b-2 border-green-500' : ''}`}
+            onClick={() => setTab('quote')}
+          >
+            Request a Quote
+          </button>
+        </div>
+
+        {tab === 'offer' && (
+          <div>
+            <p className="mb-2">{service.description}</p>
+            <p className="font-semibold mb-2">Net price: {service.price} PLN/m²</p>
+            <BarChart width={250} height={150} data={comparison} className="mx-auto">
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="price" fill="#16a34a" />
+            </BarChart>
+          </div>
+        )}
+
+        {tab === 'why' && (
+          <ul className="list-disc pl-6 space-y-1">
+            <li>Comprehensive service</li>
+            <li>Premium materials</li>
+            <li>Guaranteed deadlines</li>
+          </ul>
+        )}
+
+        {tab === 'gallery' && (
+          <div className="grid grid-cols-2 gap-2">
+            {service.images?.map((img, idx) => (
+              <img key={idx} src={img} alt="service" className="rounded" />
+            ))}
+          </div>
+        )}
+
+        {tab === 'estimate' && <CostEstimator price={service.price} />}
+
+        {tab === 'quote' && (
+          <div className="space-y-2">
+            <input
+              type="text"
+              placeholder="Your phone/email"
+              className="w-full border rounded p-2"
+            />
+            <button className="bg-green-600 text-white px-4 py-2 rounded w-full">
+              Send Request
+            </button>
+            <p className="text-sm text-gray-500 text-center">
+              On-site consultations are free.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/garden-spa/src/data.ts
+++ b/garden-spa/src/data.ts
@@ -1,0 +1,59 @@
+export interface Service {
+  id: string;
+  name: string;
+  icon: string; // emoji placeholder
+  price: number; // PLN per m2
+  description: string;
+  images?: string[];
+}
+
+export const services: Service[] = [
+  {
+    id: 'earthworks',
+    name: 'Earthworks',
+    icon: '🌀',
+    price: 155,
+    description: 'Complete soil preparation and leveling.',
+    images: ['https://via.placeholder.com/200', 'https://via.placeholder.com/200']
+  },
+  {
+    id: 'lawns',
+    name: 'Lawns',
+    icon: '🌱',
+    price: 2.8,
+    description: 'Premium lawn turf installation.',
+    images: ['https://via.placeholder.com/200', 'https://via.placeholder.com/200']
+  },
+  {
+    id: 'planting',
+    name: 'Planting & Maintenance',
+    icon: '🌳',
+    price: 50,
+    description: 'Planting services with ongoing care.',
+    images: ['https://via.placeholder.com/200', 'https://via.placeholder.com/200']
+  },
+  {
+    id: 'materials',
+    name: 'Materials & Delivery',
+    icon: '🚚',
+    price: 100,
+    description: 'Quality materials delivered to your site.',
+    images: ['https://via.placeholder.com/200', 'https://via.placeholder.com/200']
+  },
+  {
+    id: 'architecture',
+    name: 'Small Garden Architecture',
+    icon: '🏗️',
+    price: 200,
+    description: 'Eco border and garden features.',
+    images: ['https://via.placeholder.com/200', 'https://via.placeholder.com/200']
+  },
+  {
+    id: 'advantages',
+    name: 'Competitive Advantages',
+    icon: '⭐',
+    price: 0,
+    description: 'Why choose us: comprehensive service, premium materials, guaranteed deadlines.',
+    images: ['https://via.placeholder.com/200', 'https://via.placeholder.com/200']
+  }
+];

--- a/garden-spa/src/index.css
+++ b/garden-spa/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/garden-spa/src/main.tsx
+++ b/garden-spa/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/garden-spa/src/positions.ts
+++ b/garden-spa/src/positions.ts
@@ -1,0 +1,8 @@
+export const positions: Record<string, { top: string; left: string }> = {
+  earthworks: { top: '20%', left: '30%' },
+  lawns: { top: '60%', left: '20%' },
+  planting: { top: '40%', left: '70%' },
+  materials: { top: '75%', left: '55%' },
+  architecture: { top: '15%', left: '60%' },
+  advantages: { top: '50%', left: '45%' },
+};

--- a/garden-spa/tailwind.config.js
+++ b/garden-spa/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/garden-spa/tsconfig.json
+++ b/garden-spa/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/garden-spa/vite.config.ts
+++ b/garden-spa/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- update garden SPA App layout and add About/Contact sections
- expand InfoPanel with gallery and cost estimator tabs
- store placeholder images in service data
- add CostEstimator component

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683f83ac7580832088c41c489fb5656b